### PR TITLE
Improve csh configuration

### DIFF
--- a/image/extras/extras.mtree
+++ b/image/extras/extras.mtree
@@ -20,6 +20,7 @@
 ./etc/pkg/FreeBSD.conf type=file uname=root gname=wheel mode=0644
 ./boot/loader.conf type=file uname=root gname=wheel mode=644
 ./root type=dir uname=root gname=wheel mode=0755
+./root/.cshrc type=file uname=root gname=wheel mode=0555
 ./root/.ssh type=dir uname=root gname=wheel mode=0700
 ./root/.ssh/authorized_keys type=file uname=root gname=wheel mode=0600
 ./root/.gdbinit type=file uname=root gname=wheel mode=644

--- a/image/extras/root/.cshrc
+++ b/image/extras/root/.cshrc
@@ -1,0 +1,46 @@
+# $FreeBSD$
+#
+# .cshrc - csh resource script, read at beginning of execution by each shell
+#
+# see also csh(1), environ(7).
+# more examples available at /usr/share/examples/csh/
+#
+
+alias h		history 25
+alias j		jobs -l
+alias la	ls -aF
+alias lf	ls -FA
+alias ll	ls -lAF
+
+# read(2) of directories may not be desirable by default, as this will provoke
+# EISDIR errors from each directory encountered.
+# alias grep	grep -d skip
+
+# A righteous umask
+umask 22
+
+set path = (/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin $HOME/bin)
+
+setenv	EDITOR	vi
+setenv	PAGER	less
+
+if ($?prompt) then
+	# An interactive shell -- set some stuff up
+	set prompt = "%N@%m:%~ %# "
+	set promptchars = "%#"
+
+	set filec
+	set history = 1000
+	set savehist = (1000 merge)
+	set autolist = ambiguous
+	# Use history to aid expansion
+	set autoexpand
+	set autorehash
+	set mail = (/var/mail/$USER)
+	if ( $?tcsh ) then
+		bindkey "^W" backward-delete-word
+		bindkey -k up history-search-backward
+		bindkey -k down history-search-forward
+	endif
+
+endif

--- a/image/extras/root/.cshrc
+++ b/image/extras/root/.cshrc
@@ -39,6 +39,7 @@ if ($?prompt) then
 	set mail = (/var/mail/$USER)
 	if ( $?tcsh ) then
 		bindkey "^W" backward-delete-word
+		bindkey "\e[3~" delete-char
 		bindkey -k up history-search-backward
 		bindkey -k down history-search-forward
 	endif

--- a/image/extras/root/.cshrc
+++ b/image/extras/root/.cshrc
@@ -21,7 +21,13 @@ umask 22
 
 set path = (/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin $HOME/bin)
 
-setenv	EDITOR	vi
+if ( -f /usr/local/bin/vim ) then
+	setenv	EDITOR	vim
+else if ( -f /usr/local/bin/nano ) then
+	setenv	EDITOR	nano
+else
+	setenv	EDITOR	vi
+endif
 setenv	PAGER	less
 
 if ($?prompt) then


### PR DESCRIPTION
Handle the delete key and choose EDITOR based on installed editors.

Note that we DO NOT want to reimage nodes as the course already started. This change is for the future or in case a node must be manually reimaged.